### PR TITLE
Update dev charts to enable/disable persistent storage.

### DIFF
--- a/helm/dev/charts/besu-node/templates/node-statefulset.yaml
+++ b/helm/dev/charts/besu-node/templates/node-statefulset.yaml
@@ -51,6 +51,7 @@ mountOptions:
 parameters:
   skuName: Standard_LRS
 
+{{- if .Values.node.storage.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -63,10 +64,10 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: "{{ .Values.node.pvcSizeLimit }}" 
+      storage: "{{ .Values.node.storage.pvcSizeLimit }}"
+{{- end }}
 
-
-{{- if .Values.nodeFlags.privacy }}
+{{- if and .Values.nodeFlags.privacy .Values.node.storage.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -79,9 +80,8 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: "{{ .Values.node.pvcSizeLimit }}" 
-
-{{- end}}
+      storage: "{{ .Values.node.storage.pvcSizeLimit }}"
+{{- end }}
 
 ---
 apiVersion: apps/v1
@@ -165,11 +165,11 @@ spec:
           - name: ORION_CLIENTURL
             value: "http://{{ include "besu-node.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.privacy.orionConfig.clientport}}/"
           - name: ORION_OTHERNODES
-          {{- if eq .Values.privacy.othernodes "self" }}            
+          {{- if eq .Values.privacy.othernodes "self" }}
             value: "http://{{ include "besu-node.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.privacy.orionConfig.nodeport}}/"
-          {{- else }}            
-            value: {{ .Values.privacy.othernodes | quote }}            
-          {{- end}}            
+          {{- else }}
+            value: {{ .Values.privacy.othernodes | quote }}
+          {{- end}}
 
         volumeMounts:
           - name: orion-key
@@ -243,7 +243,7 @@ spec:
           - name: orion-key
             mountPath: /orionsecrets
             readOnly: true
-        {{- end}} 
+        {{- end}}
           - name: key
             mountPath: /secrets
             readOnly: true
@@ -279,7 +279,7 @@ spec:
           - -c
         args:
           - |
-            exec 
+            exec
             export BOOTNODE_ENODE1="enode://${BOOTNODE1_PUBKEY}@besu-node-bootnode-1-0.besu-node-bootnode-1.{{ .Release.Namespace }}.svc.cluster.local:30303" ;
             export BOOTNODE_ENODE2="enode://${BOOTNODE2_PUBKEY}@besu-node-bootnode-2-0.besu-node-bootnode-2.{{ .Release.Namespace }}.svc.cluster.local:30303" ;
             /opt/besu/bin/besu \
@@ -291,15 +291,15 @@ spec:
               --privacy-enabled=true \
               --privacy-url="http://{{ include "besu-node.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.privacy.orionConfig.clientport}}" \
               --privacy-public-key-file=/orionsecrets/public.key \
-          {{- end -}} 
-              --bootnodes=${BOOTNODE_ENODE1},${BOOTNODE_ENODE2} 
+          {{- end -}}
+              --bootnodes=${BOOTNODE_ENODE1},${BOOTNODE_ENODE2}
 
         livenessProbe:
           httpGet:
             path: /liveness
             port: 8545
           initialDelaySeconds: 180
-          periodSeconds: 60              
+          periodSeconds: 60
       volumes:
       - name: key
         secret:
@@ -314,8 +314,12 @@ spec:
         configMap:
           name: {{ include "besu-node.fullname" . }}-besu-config
       - name: data
+        {{- if .Values.node.storage.enabled }}
         persistentVolumeClaim:
-          claimName: {{ include "besu-node.fullname" . }}-pvc-besu      
+          claimName: {{ include "besu-node.fullname" . }}-pvc-besu
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
       {{- if .Values.node.permissions.enabled }}
       - name: permissions-config
         configMap:
@@ -329,8 +333,10 @@ spec:
         configMap:
           name: {{ include "besu-node.fullname" . }}-orion-config
       - name: orion-data
+        {{- if .Values.node.storage.enabled }}
         persistentVolumeClaim:
-          claimName: {{ include "besu-node.fullname" . }}-pvc-orion               
+          claimName: {{ include "besu-node.fullname" . }}-pvc-orion
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
       {{- end }}
-
-

--- a/helm/dev/charts/besu-node/values.yaml
+++ b/helm/dev/charts/besu-node/values.yaml
@@ -19,8 +19,10 @@ nodeFlags:
 node:
   # privKey:
   # pubKey:
-  pvcSizeLimit: "10Gi"
-  pvcStorageClass: "standard"
+  storage:
+    enabled: true
+    pvcSizeLimit: "10Gi"
+    pvcStorageClass: "standard"
   resources:
     memRequest: "1024Mi"
     memLimit: "2048Mi"
@@ -90,7 +92,7 @@ privacy:
   # password:
   # the orion bootnode so to speak
   othernodes: "self"
-  orionConfig: 
+  orionConfig:
     nodeport: 8080
     nodenetworkinterface: "0.0.0.0"
     clientport: 8888

--- a/helm/dev/charts/quorum-node/templates/node-statefulset.yaml
+++ b/helm/dev/charts/quorum-node/templates/node-statefulset.yaml
@@ -51,6 +51,7 @@ parameters:
   skuName: Standard_LRS
 
 ---
+{{- if .Values.node.quorumConfig.storage.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -62,8 +63,8 @@ spec:
   storageClassName: {{ include "quorum-node.fullname" . }}-storage
   resources:
     requests:
-      storage: "{{ .Values.node.quorumConfig.pvcSizeLimit }}"
-
+      storage: "{{ .Values.node.storage.quorumConfig.pvcSizeLimit }}"
+{{- end }}
 
 ---
 apiVersion: apps/v1
@@ -136,19 +137,19 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           - name: TESSERA_CONFIG_TYPE
-            value: "-09"              
+            value: "-09"
           - name: PRIVATE_CONFIG
             value: "/ipc/tm/tm.ipc"
         volumeMounts:
           - name: tessera-secrets
-            mountPath: {{ .Values.node.quorumConfig.keysPath }} 
+            mountPath: {{ .Values.node.quorumConfig.keysPath }}
             readOnly: true
           - name: data
             mountPath: {{ .Values.node.quorumConfig.dataDir }}
           - name: ipc-volume
             mountPath: /ipc/
           - name: tessera-peers
-            mountPath: /config/tessera-peers            
+            mountPath: /config/tessera-peers
         ports:
           - name: tessera
             containerPort: {{ .Values.node.quorumConfig.tessera.port }}
@@ -161,7 +162,7 @@ spec:
           - -c
         args:
           - |
-            exec 
+            exec
             mkdir -p /ipc/tm/;
             mkdir {{ .Values.node.quorumConfig.dataDir }}/tm/;
             cp {{ .Values.node.quorumConfig.keysPath }}/tm.* {{ .Values.node.quorumConfig.dataDir }}/tm/ ;
@@ -241,11 +242,11 @@ spec:
           - name: QUORUM_CONSENSUS
             value: "istanbul"
           - name: PRIVATE_CONFIG
-          {{- if .Values.nodeFlags.privacy }}       
+          {{- if .Values.nodeFlags.privacy }}
             value: "/ipc/tm/tm.ipc"
-          {{ else }}   
+          {{ else }}
             value: "ignore"
-          {{- end }}  
+          {{- end }}
           - name: BOOTNODE1_PUBKEY
             valueFrom:
               secretKeyRef:
@@ -260,7 +261,7 @@ spec:
             readOnly: true
           - name: static-nodes
             mountPath: /config/static/
-            readOnly: true  
+            readOnly: true
           - name: data
             mountPath: {{ .Values.node.quorumConfig.dataDir }}
           - name: ipc-volume
@@ -286,13 +287,13 @@ spec:
           - -c
         args:
           - |
-            exec 
+            exec
             mkdir -p /ipc/geth/
-            apk add curl 
-          {{- if .Values.nodeFlags.privacy }}   
+            apk add curl
+          {{- if .Values.nodeFlags.privacy }}
             until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9000/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
             echo transaction manager is up;
-          {{- end }}  
+          {{- end }}
             geth --datadir={{ .Values.node.quorumConfig.dataDir }}/dd init {{ .Values.node.quorumConfig.genesisPath }}
             cp {{ .Values.node.quorumConfig.keysPath }}/nodekey {{ .Values.node.quorumConfig.dataDir }}/dd/geth/nodekey
             cp /config/static/static-nodes.json {{ .Values.node.quorumConfig.dataDir }}/dd/geth/static-nodes.json
@@ -312,18 +313,18 @@ spec:
             --port {{ .Values.node.quorumConfig.p2p.port }} \
           {{- if .Values.node.quorumConfig.rpc.enabled }}
             --rpc --rpcaddr {{ .Values.node.quorumConfig.rpc.addr }} --rpcport {{ .Values.node.quorumConfig.rpc.port }} --rpccorsdomain {{ .Values.node.quorumConfig.rpc.corsDomain | quote }} --rpcvhosts {{ .Values.node.quorumConfig.rpc.vHosts | quote }} --rpcapi {{ .Values.node.quorumConfig.rpc.api | quote }} \
-          {{- end }}   
+          {{- end }}
           {{- if .Values.node.quorumConfig.ws.enabled }}
             --ws --wsaddr {{ .Values.node.quorumConfig.ws.addr }} --wsport {{ .Values.node.quorumConfig.ws.port }} --wsorigins {{ .Values.node.quorumConfig.ws.origins | quote }} --wsapi {{ .Values.node.quorumConfig.ws.api | quote }} \
-          {{- end }}  
+          {{- end }}
           {{- if .Values.node.quorumConfig.graphql.enabled }}
             --graphql --graphql.addr {{ .Values.node.quorumConfig.graphql.addr }} --graphql.port {{ .Values.node.quorumConfig.graphql.port }} --graphql.corsdomain {{ .Values.node.quorumConfig.graphql.corsDomain | quote }} --graphql.vhosts {{ .Values.node.quorumConfig.graphql.vHosts | quote }} \
           {{- end }}
           {{- if hasKey .Values.node.quorumConfig.account "unlock" }}
              --unlock {{ .Values.node.quorumConfig.account.unlock }} --allow-insecure-unlock --password {{ .Values.node.quorumConfig.account.password }} \
           {{- end }}
-            --metrics --metrics.expensive --pprof --pprofaddr={{ .Values.node.quorumConfig.metrics.pprofaddr | quote }} 
-             
+            --metrics --metrics.expensive --pprof --pprofaddr={{ .Values.node.quorumConfig.metrics.pprofaddr | quote }}
+
       volumes:
       - name: secrets
         secret:
@@ -339,13 +340,17 @@ spec:
           name: quorum-node-enodes
           items:
             - key: static-nodes.json
-              path: static-nodes.json    
+              path: static-nodes.json
       - name: ipc-volume
-        emptyDir: {}                        
+        emptyDir: {}
       - name: data
+        {{- if .Values.node.quorumConfig.storage.enabled }}
         persistentVolumeClaim:
           claimName: {{ include "quorum-node.fullname" . }}-pvc
-      {{- if .Values.nodeFlags.privacy }}   
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      {{- if .Values.nodeFlags.privacy }}
       - name: tessera-peers
         configMap:
           name: tessera-peers
@@ -355,4 +360,4 @@ spec:
       - name: tessera-secrets
         secret:
           secretName: {{ include "quorum-node.fullname" . }}-tessera-keys
-      {{- end }}                 
+      {{- end }}

--- a/helm/dev/charts/quorum-node/values.yaml
+++ b/helm/dev/charts/quorum-node/values.yaml
@@ -29,8 +29,10 @@ node:
     cpuRequest: "100m"
     cpuLimit: "500m"
   quorumConfig:
-    pvcSizeLimit: "50Gi"
-    pvcStorageClass: "standard"
+    storage:
+      enabled: true
+      pvcSizeLimit: "50Gi"
+      pvcStorageClass: "standard"
     networkId: 10
     replicaCount: 1
     genesisPath: "/config/quorum/genesis.json"


### PR DESCRIPTION
Feel free to reject this PR, it just allows enabling/disabling persistent storage (just for dev charts) which I found useful while testing these charts in a kind Kubernetes cluster.